### PR TITLE
Complete porting to Python3

### DIFF
--- a/src/hostname.c
+++ b/src/hostname.c
@@ -26,6 +26,8 @@
  * $FreeBSD$
  */
 
+#include "py2to3.h"
+
 static char PyFB_gethostname__doc__[] =
 "gethostname():\n"
 "returns the standard host name for the current processor, as\n"

--- a/src/kqueue.c
+++ b/src/kqueue.c
@@ -29,6 +29,8 @@
 
 #include <sys/event.h>
 
+#include "py2to3.h"
+
 #define MAX_KEVENTS 512
 
 /* Event filters */

--- a/src/kqueue.c
+++ b/src/kqueue.c
@@ -246,16 +246,16 @@ static char kevent_doc[] =
 
 static PyTypeObject KEventType = {
 	PyObject_HEAD_INIT(NULL)
-	tp_name:	"kevent",
-	tp_basicsize:	sizeof(keventobject),
-	tp_dealloc:	(destructor)kevent_dealloc,
-	tp_getattro:	PyObject_GenericGetAttr,
-	tp_repr:	(reprfunc)kevent_repr,
-	tp_flags:	Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
-	tp_traverse:	(traverseproc)kevent_traverse,
-	tp_members:	kevent_memberlist,
-	tp_new:		kevent_new,
-	tp_doc:		kevent_doc,
+	.tp_name =	"kevent",
+	.tp_basicsize =	sizeof(keventobject),
+	.tp_dealloc =	(destructor)kevent_dealloc,
+	.tp_getattro =	PyObject_GenericGetAttr,
+	.tp_repr =	(reprfunc)kevent_repr,
+	.tp_flags =	Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
+	.tp_traverse =	(traverseproc)kevent_traverse,
+	.tp_members =	kevent_memberlist,
+	.tp_new =	kevent_new,
+	.tp_doc =	kevent_doc,
 };
 
 
@@ -554,13 +554,13 @@ static char kqueue_doc[] =
 
 static PyTypeObject KQueueType = {
 	PyObject_HEAD_INIT(NULL)
-	tp_name:	"kqueue",
-	tp_basicsize:	sizeof(kqueueobject),
-	tp_dealloc:	(destructor)kqueue_dealloc,
-	tp_getattro:	PyObject_GenericGetAttr,
-	tp_flags:	Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
-	tp_traverse:	(traverseproc)kqueue_traverse,
-	tp_methods:	kqueue_methods,
-	tp_new:		kqueue_new,
-	tp_doc:		kqueue_doc,
+	.tp_name =	"kqueue",
+	.tp_basicsize =	sizeof(kqueueobject),
+	.tp_dealloc =	(destructor)kqueue_dealloc,
+	.tp_getattro =	PyObject_GenericGetAttr,
+	.tp_flags =	Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
+	.tp_traverse =	(traverseproc)kqueue_traverse,
+	.tp_methods =	kqueue_methods,
+	.tp_new =	kqueue_new,
+	.tp_doc =	kqueue_doc,
 };

--- a/src/kqueue.c
+++ b/src/kqueue.c
@@ -335,7 +335,7 @@ static char kqueue_event_doc[] =
 "may be used for the changelist and return value.";
 
 /* Call kevent(2) and do appropriate digestion of lists. */
-#define UDATAREFKEY(ev)	(PyString_FromStringAndSize((char *)&(ev), \
+#define UDATAREFKEY(ev)	(PyBytes_FromStringAndSize((char *)&(ev), \
 			 sizeof(uintptr_t)+sizeof(short)))
 
 static PyObject *

--- a/src/kqueue.c
+++ b/src/kqueue.c
@@ -93,7 +93,7 @@ typedef struct {
 
 static PyTypeObject KEventType;
 
-#define KEvent_Check(v)  ((v)->ob_type == &KEventType)
+#define KEvent_Check(v)  (Py_TYPE(v) == &KEventType)
 
 /* kevent methods */
 
@@ -133,7 +133,7 @@ static void
 kevent_dealloc(keventobject *self)
 {
 	Py_XDECREF((PyObject *)self->e.udata);
-	self->ob_type->tp_free((PyObject *)self);
+	Py_TYPE(self)->tp_free((PyObject *)self);
 }
 
 static int
@@ -269,7 +269,7 @@ typedef struct {
 
 static PyTypeObject KQueueType;
 
-#define KQueue_Check(v)	((v)->ob_type == &KQueueType)
+#define KQueue_Check(v)	(Py_TYPE(v) == &KQueueType)
 
 /* kqueue methods */
 
@@ -308,7 +308,7 @@ kqueue_dealloc(kqueueobject *self)
 		self->fd = -1;
 	}
 	Py_XDECREF(self->udrefkeep);
-	self->ob_type->tp_free((PyObject *)self);
+	Py_TYPE(self)->tp_free((PyObject *)self);
 }
 
 static int

--- a/src/login.c
+++ b/src/login.c
@@ -26,6 +26,8 @@
  * $FreeBSD$
  */
 
+#include "py2to3.h"
+
 static char PyFB_getlogin__doc__[] =
 "getlogin():\n"
 "returns the login name of the user associated with the current\n"

--- a/src/netstat.c
+++ b/src/netstat.c
@@ -36,6 +36,8 @@
 #include <netinet/udp.h>
 #include <netinet/udp_var.h>
 
+#include "py2to3.h"
+
 EXPCONST(int IFF_UP)
 EXPCONST(int IFF_BROADCAST)
 EXPCONST(int IFF_DEBUG)

--- a/src/process.c
+++ b/src/process.c
@@ -26,6 +26,8 @@
  * $FreeBSD$
  */
 
+#include "py2to3.h"
+
 static char PyFB_getprogname__doc__[] =
 "getprogname():\n"
 "The getprogname() function returns the name of the program.  If the\n"

--- a/src/py2to3.h
+++ b/src/py2to3.h
@@ -26,6 +26,9 @@
  * $FreeBSD$
  */
 
+#ifndef __PY2TO3_H
+#define __PY2TO3_H
+
 #if !defined(PY_MAJOR_VERSION)
     #error PY_MAJOR_VERSION is not defined
 #endif
@@ -34,12 +37,42 @@
     #define PyInt_Check(OB) PyLong_Check(OB)
     #define PyInt_FromLong(V) PyLong_FromLong(V)
     #define PyInt_AsLong(OB) PyLong_AsLong(OB)
-    #define PyString_FromStringAndSize(V, L) PyUnicode_FromStringAndSize(V, L)
-    #define PyString_FromString(V) PyUnicode_FromString(V)
+    #define PyString_FromStringAndSize(V, L) PyUnicode_DecodeASCII(V, L, NULL)
+    #define PyString_FromString(V) PyUnicode_DecodeASCII(V, strlen(V), NULL)
     #define PyString_FromFormat(F, A...) PyUnicode_FromFormat(F, ## A)
-    #define PyString_Size(OB) PyUnicode_GET_DATA_SIZE(OB)
-    #define PyString_AS_STRING(OB) PyUnicode_AS_DATA(OB)
     #define _PyString_Join(OB1, OB2) PyUnicode_Join(OB1, OB2)
     #define PyString_Check(OB) PyUnicode_Check(OB)
-    #define PyString_GET_SIZE(OB) PyUnicode_GET_DATA_SIZE(OB)
+    #define PyString_GET_SIZE(OB) PyString_Size(OB)
+    #define PyString_AS_STRING(OB) _PyString_AS_STRING(OB, alloca(1024), 1024)
+
+static inline const char *
+_PyString_AS_STRING(PyObject *us, char *sbuf, size_t blen)
+{
+    PyObject *as;
+
+    as = PyUnicode_AsASCIIString(us);
+    if (as == NULL)
+        return (NULL);
+    strncpy(sbuf, PyBytes_AsString(as), blen);
+    Py_DECREF(as);
+    return (sbuf);
+}
+
+static inline ssize_t
+PyString_Size(PyObject *us)
+{
+    PyObject *as;
+    ssize_t rval;
+
+    as = PyUnicode_AsASCIIString(us);
+    if (as == NULL)
+        return (-1);
+    rval = strlen(PyBytes_AsString(as));
+    Py_DECREF(as);
+    return (rval);
+}
+#else
+    #define PyBytes_FromStringAndSize(V, L) PyString_FromStringAndSize(V, L)
 #endif
+
+#endif /* __PY2TO3_H */

--- a/src/py2to3.h
+++ b/src/py2to3.h
@@ -71,8 +71,6 @@ PyString_Size(PyObject *us)
     Py_DECREF(as);
     return (rval);
 }
-#else
-    #define PyBytes_FromStringAndSize(V, L) PyString_FromStringAndSize(V, L)
-#endif
+#endif /* PY_MAJOR_VERSION >= 3 */
 
 #endif /* __PY2TO3_H */

--- a/src/py2to3.h
+++ b/src/py2to3.h
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2005 Soeren Straarup
+ * Copyright (c) 2018 Sippy Software, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,34 +26,20 @@
  * $FreeBSD$
  */
 
-#if __FreeBSD_version >= 500101
-
-LIB_DEPENDS(geom)
-#include <libgeom.h>
-
-#include "py2to3.h"
-
-static char PyFB_geom_getxml__doc__[] =
-"geom_getxml():\n"
-"returns a string with a xml layout of the geom layer\n";
-
-static PyObject *
-PyFB_geom_getxml(PyObject *self)
-{
-	PyObject *r;
-	char *xml;
-
-	xml = geom_getxml();
-	if (xml == NULL)
-		return OSERROR();
-
-	r = PyString_FromString(xml);
-	free(xml);
-	return r;
-}
-
+#if !defined(PY_MAJOR_VERSION)
+    #error PY_MAJOR_VERSION is not defined
 #endif
 
-/*
- * The End, no more, it is over and out..
- */
+#if PY_MAJOR_VERSION >= 3
+    #define PyInt_Check(OB) PyLong_Check(OB)
+    #define PyInt_FromLong(V) PyLong_FromLong(V)
+    #define PyInt_AsLong(OB) PyLong_AsLong(OB)
+    #define PyString_FromStringAndSize(V, L) PyUnicode_FromStringAndSize(V, L)
+    #define PyString_FromString(V) PyUnicode_FromString(V)
+    #define PyString_FromFormat(F, A...) PyUnicode_FromFormat(F, ## A)
+    #define PyString_Size(OB) PyUnicode_GET_DATA_SIZE(OB)
+    #define PyString_AS_STRING(OB) PyUnicode_AS_DATA(OB)
+    #define _PyString_Join(OB1, OB2) PyUnicode_Join(OB1, OB2)
+    #define PyString_Check(OB) PyUnicode_Check(OB)
+    #define PyString_GET_SIZE(OB) PyUnicode_GET_DATA_SIZE(OB)
+#endif

--- a/src/sysctl.c
+++ b/src/sysctl.c
@@ -170,6 +170,8 @@ parse_oid_sequence(PyObject *name, int *oid, size_t *size)
 static int
 parse_oid_argument(PyObject *name, int *oid, size_t *size)
 {
+	const char *cp;
+
 	if (PyString_Check(name)) {
 		int r;
 		if (PyString_GET_SIZE(name) == 0) {
@@ -177,7 +179,10 @@ parse_oid_argument(PyObject *name, int *oid, size_t *size)
 			return 0;
 		}
 		*size = CTL_MAXNAME;
-		r = sysctlnametomib(PyString_AS_STRING(name), oid, size);
+		cp = PyString_AS_STRING(name);
+		if (cp == NULL)
+			return -1;
+		r = sysctlnametomib(cp, oid, size);
 		if (r == -1) {
 			OSERROR();
 			return -1;
@@ -289,7 +294,8 @@ PyFB_sysctl(PyObject *self, PyObject *args, PyObject *kwds)
 	PyObject *oid, *ret, *newobj = NULL;
 	int oldlenhint = -1;
 	unsigned int kind;
-	void *oldp, *newp;
+	void *oldp;
+	const void *newp;
 	size_t oldlen, newlen, qoidsize;
 	union multitype val;
 	int qoid[CTL_MAXNAME];

--- a/src/sysctl.c
+++ b/src/sysctl.c
@@ -29,6 +29,8 @@
 #include <sys/param.h>
 #include <sys/sysctl.h>
 
+#include "py2to3.h"
+
 static char PyFB_getloadavg__doc__[] =
 "getloadavg():\n"
 "returns the number of processes in the system run queue averaged\n"

--- a/tests/test_kqueue.py
+++ b/tests/test_kqueue.py
@@ -32,9 +32,10 @@ class Test_kqueue(unittest.TestCase):
             del ev
             self.__shuffle_freeheaps()
 
-            os.write(wr, 'unittest')
+            data = 'unittest'.encode()
+            os.write(wr, data)
             r = kq.event(None, 1)
-            self.assertEqual(os.read(rd, 10), 'unittest')
+            self.assertEqual(os.read(rd, 10), data)
             self.assertEqual(r[0].udata, [1, 2, 3, 4])
             del r
 
@@ -49,11 +50,5 @@ class Test_kqueue(unittest.TestCase):
         # drive some memory allocations to shuffle free heaps.
         [[x]*50 for x in range(1000)]
 
-
-def test_main():
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(Test_kqueue))
-    test_support.run_suite(suite)
-
 if __name__ == "__main__":
-    test_main()
+    unittest.main()

--- a/tests/test_sysctl.py
+++ b/tests/test_sysctl.py
@@ -22,10 +22,5 @@ class Test_sysctl(unittest.TestCase):
         for i in range(3):
             self.assertTrue(0 <= lavg[i] <= 1)
 
-def test_main():
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(Test_sysctl))
-    test_support.run_suite(suite)
-
 if __name__ == "__main__":
-    test_main()
+    unittest.main()


### PR DESCRIPTION
This makes module buildable with both 2.7 and 3.6 python. Both systctl and kqueue test cases pass, no further functionality check has been performed.